### PR TITLE
Keyboard navigation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,8 @@
     "webfontloader": "~1.5.8",
     "greensock": "~1.14.2",
     "angular-animate": "~1.3.2",
-    "bowser": "~0.7.2"
+    "bowser": "~0.7.2",
+    "mousetrap": "~1.4.6"
   },
   "devDependencies": {
     "almond": "~0.3.0",

--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -27,6 +27,7 @@
             'webfontloader': '../scripts/components/webfontloader/webfontloader',
             'gs': '../scripts/components/greensock/TweenMax',
             'bowser': '../scripts/components/bowser/bowser',
+            'mousetrap': '../scripts/components/mousetrap/mousetrap',
             'experience': '../scripts/experience'
         },
 

--- a/src/scripts/experience/explore-mode.js
+++ b/src/scripts/experience/explore-mode.js
@@ -286,13 +286,24 @@ define(['pixi', 'experience/mode', 'experience/issue'], function (PIXI, Mode, Is
         }
     };
 
+    ExploreMode.prototype._focusIssue = function(issue) {
+        issue.setTextAlwaysVisible(true);
+    };
+
+    ExploreMode.prototype._blurIssue = function(issue) {
+        issue.setTextAlwaysVisible(false);
+    };
+
     ExploreMode.prototype._onStartShow = function () {
         // set position for issues
         var issue;
         var i;
+        var focusableIssues = [];
 
         for (i = 0; i < this._canvas.issues.length; i ++) {
             issue = this._canvas.issues[i];
+            focusableIssues.push(issue);
+
             issue.setMode(Issue.MODE_EXPLORE);
             issue.moveTo(
                 issue.exploreX,
@@ -302,13 +313,19 @@ define(['pixi', 'experience/mode', 'experience/issue'], function (PIXI, Mode, Is
             issue.exploreMouseOver = this._mouseOverIssue.bind(this);
             issue.exploreMouseOut = this._mouseOutIssue.bind(this);
             issue.exploreTap = this._tapIssue.bind(this);
+            issue.exploreFocus = this._focusIssue.bind(this);
+            issue.exploreBlur = this._blurIssue.bind(this);
             issue.mouseOverS.add(issue.exploreMouseOver);
             issue.mouseOutS.add(issue.exploreMouseOut);
             issue.tapS.add(issue.exploreTap);
+            issue.focusS.add(issue.exploreFocus);
+            issue.blurS.add(issue.exploreBlur);
         }
 
         for (i = 0; i < this._canvas.tags.length; i ++) {
             issue = this._canvas.tags[i];
+            focusableIssues.push(issue);
+
             issue.setMode(Issue.MODE_TAG);
             issue._x0 = issue.exploreX;
             issue._y0 = issue.exploreY;
@@ -316,9 +333,13 @@ define(['pixi', 'experience/mode', 'experience/issue'], function (PIXI, Mode, Is
             issue.exploreMouseOver = this._mouseOverIssue.bind(this);
             issue.exploreMouseOut = this._mouseOutIssue.bind(this);
             issue.exploreTap = this._tapIssue.bind(this);
+            issue.exploreFocus = this._focusIssue.bind(this);
+            issue.exploreBlur = this._blurIssue.bind(this);
             issue.mouseOverS.add(issue.exploreMouseOver);
             issue.mouseOutS.add(issue.exploreMouseOut);
             issue.tapS.add(issue.exploreTap);
+            issue.focusS.add(issue.exploreFocus);
+            issue.blurS.add(issue.exploreBlur);
         }
 
         for (i = 0; i < this._canvas.fakes.length; i ++) {
@@ -334,6 +355,15 @@ define(['pixi', 'experience/mode', 'experience/issue'], function (PIXI, Mode, Is
         // start a new autoMode timeout
         this._endAutoMode(true);
         setTimeout(this._onShow.bind(this), 500);
+
+        // Append issues to DOM for keyboard navigation.
+        // Sort issues and tags by position.
+        focusableIssues.sort(function(a, b) {
+            return a.exploreY - b.exploreY;
+        });
+        for (i = 0; i < focusableIssues.length; i++) {
+            this._canvas.appendDomIssue(focusableIssues[i]);
+        }
     };
 
     ExploreMode.prototype._onStartHide = function () {
@@ -346,6 +376,8 @@ define(['pixi', 'experience/mode', 'experience/issue'], function (PIXI, Mode, Is
             issue.mouseOverS.remove(issue.exploreMouseOver);
             issue.mouseOutS.remove(issue.exploreMouseOut);
             issue.tapS.remove(issue.exploreTap);
+            issue.focusS.remove(issue.exploreFocus);
+            issue.blurS.remove(issue.exploreBlur);
         }
 
         for (i = 0; i < this._canvas.tags.length; i ++) {
@@ -354,6 +386,8 @@ define(['pixi', 'experience/mode', 'experience/issue'], function (PIXI, Mode, Is
             issue.mouseOverS.remove(issue.exploreMouseOver);
             issue.mouseOutS.remove(issue.exploreMouseOut);
             issue.tapS.remove(issue.exploreTap);
+            issue.focusS.remove(issue.exploreFocus);
+            issue.blurS.remove(issue.exploreBlur);
         }
 
         for (i = 0; i < this._canvas.fakes.length; i ++) {
@@ -366,6 +400,8 @@ define(['pixi', 'experience/mode', 'experience/issue'], function (PIXI, Mode, Is
         this._endAutoMode();
 
         setTimeout(this._onHide.bind(this), 100);
+
+        this._canvas.clearDomIssues();
     };
 
     return ExploreMode;

--- a/src/scripts/experience/tag-issues-mode.js
+++ b/src/scripts/experience/tag-issues-mode.js
@@ -4,13 +4,15 @@ define([
     'signals',
     'experience/mode',
     'experience/issues-mode',
-    'experience/issue'
+    'experience/issue',
+    'mousetrap'
 ], function (
     PIXI,
     signals,
     Mode,
     IssuesMode,
-    Issue
+    Issue,
+    Mousetrap
 ) {
     'use strict';
 
@@ -57,7 +59,7 @@ define([
         this._closeButtonContainer.y = this._canvas.canvasSize.y / 2;
         this._closeButtonContainer.addChild(this._closeButton);
         this._canvas.addChild(this._closeButtonContainer);
-     };
+    };
 
     TagIssuesMode.prototype.setTag = function (data) {
         this._tag = this._canvas.getElementByData(data);
@@ -120,6 +122,9 @@ define([
             issue.moveTo(issue.issueX, issue.issueY);
             // so mouse over doesnt block animation
             setTimeout(this._setIssueMouseEvents.bind(this), 500, issue);
+
+            // Append issue to DOM for keyboard navigation.
+            this._canvas.appendDomIssue(issue);
         }
 
         var x0 = this._tag._x0;
@@ -144,6 +149,11 @@ define([
         this._canvas._stage.touchmove = this._onTouching.bind(this);
 
         setTimeout(this._onShow.bind(this), 500);
+
+        // When ESC is pressed, close this view.
+        Mousetrap.bind('esc', (function() {
+            this._onPressClose();
+        }).bind(this));
     };
 
     TagIssuesMode.prototype._onStartHide = function () {
@@ -164,6 +174,9 @@ define([
         this._canvas.renderStartS.remove(this._drawLinesBind);
 
         setTimeout(this._onHide.bind(this), 100);
+
+        this._canvas.clearDomIssues();
+        Mousetrap.unbind('esc');
     };
 
     return TagIssuesMode;

--- a/src/scripts/experience/topic.js
+++ b/src/scripts/experience/topic.js
@@ -25,6 +25,10 @@ define([
         this._issues = issues;
         this._fakes = fakes;
 
+        for (var i  = 0; i < this._issues.length; i++) {
+            this._issues[i].topic = this;
+        }
+
         this.elm = new PIXI.DisplayObjectContainer();
 
         this.mouseOverS = new signals.Signal();
@@ -216,9 +220,10 @@ define([
     };
 
     /**
-    * When hovering a topic
+    * When hovering a topic. If force is true, ignore the check to see if this is
+    * a valid mouseOver.
     */
-    Topic.prototype._mouseOver = function () {
+    Topic.prototype._mouseOver = function (force) {
         Topic.SELECTED_TOPIC = this;
 
         var i;
@@ -260,17 +265,20 @@ define([
         this.elm.addChild(this._linearArea);
 
         // make sure mouse is over
-        setTimeout(function () {
-            if (!this._isMouseOver()) {
-                this._mouseOut();
-            }
-        }.bind(this), 100);
+        if (!force) {
+            setTimeout(function () {
+                if (!this._isMouseOver()) {
+                    this._mouseOut();
+                }
+            }.bind(this), 100);
+        }
 
         this.mouseOverS.dispatch(this);
     };
 
     /**
-    * When the mouse leaves a topic
+    * When the mouse leaves a topic. If force is true, ignore the check to see
+    * if this is a valid mouseOut.
     */
     Topic.prototype._mouseOut = function (force) {
         // make sure it's really a mouse out


### PR DESCRIPTION
Phew! This adds decent support for keyboard navigation to the canvas parts of the site. There's some things missing, primarily:

- The styling of the site makes it hard to tell where the keyboard is currently focused on the non-canvas parts of the site.
- The scrolling on the checklist view when you tab between items is really choppy, but the scrolling math there is so complicated that I didn't think it worth it to delay this PR any further before I figured it out properly.

Since this site is so complicated, I'll leave some comments on the diff explaining some things.

This should be deployed on http://lorax.mkelly.me/ within a few minutes of this PR being up.