### PR TITLE
Fix bug 1113276: Add s3 deployment via grunt-s3 and Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+language: node_js
+node_js:
+  - "0.10"
+env:
+  - AWS_S3_BUCKET=lorax
+  - secure: "AKlWt93iVTfCgisuqqA/r0r0nmmtuCzPqw67mMHqOKBh7V3FXFY6mquLcwqs2cCJYU7wBbM4BGmOv3CPF2LThLluBbc2n2zbDAFmPHfcRx8xd0jhUhYo2b6x3nNYqM1qLVnpIbwW/zCr9JdpGP4KMBpvRcEpBZ9OWIacAMolUSw="
+  - secure: "AN6quZQT9DGpt7cXqOcSN7CWR0G6tNV9D4SO7REjR+FaaTtDdG108o7Gb5p/dm0Kg2XYb92t5pHEjXkStOexwqTwjP+3JdCBB4euYJGg8yeLJGj1qBxEtnVb8J6LaNtOGRYHiJiBar3P10ut60wIuJT9dJjkT6OuLroHkm/OAzs="
+install:
+  - npm install
+  - bower install
+script: node_modules/.bin/grunt build
+after_success:
+  - node_modules/.bin/grunt s3

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -281,6 +281,32 @@ module.exports = function (grunt) {
                 base: 'dist'
             },
             src: ['**']
+        },
+
+        s3: {
+            options: {
+                bucket: process.env.AWS_S3_BUCKET,
+                access: 'public-read',
+                headers: {
+                    // Two Hour cache policy (1000 * 60 * 60 * 2)
+                    'Cache-Control': 'max-age=7200, public',
+                    'Expires': new Date(Date.now() + 7200000).toUTCString()
+                }
+            },
+            prod: {
+                sync: [
+                    {
+                        src: 'dist/**',
+                        dest: '',
+                        rel: 'dist',
+                        options: {
+                            verify: true,
+                            gzip: true,
+                            gzipExclude: ['.png', '.ico', '.txt', '.jpg', '.woff']
+                        }
+                    }
+                ]
+            }
         }
     });
 

--- a/package.json
+++ b/package.json
@@ -7,12 +7,11 @@
     "url": "git://github.com/mozilla/lorax.git"
   },
   "devDependencies": {
+    "bower": "~1.3.0",
     "connect-modrewrite": "~0.7.9",
     "grunt": "~0.4.5",
-    "grunt-cli": "~0.1.11",
-    "bower": "~1.3.0",
-    "less": "~2.3.0",
     "grunt-bower-task": "~0.4.0",
+    "grunt-cli": "~0.1.11",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-compass": "~0.9.1",
     "grunt-contrib-concat": "~0.5.0",
@@ -26,8 +25,10 @@
     "grunt-gh-pages": "^0.9.1",
     "grunt-grunticon": "~1.3.0",
     "grunt-notify": "~0.3.1",
+    "grunt-s3": "^0.2.0-alpha.3",
     "grunt-svgmin": "~2.0.0",
     "grunt-usemin": "~2.4.0",
+    "less": "~2.3.0",
     "load-grunt-tasks": "~0.6.0"
   }
 }


### PR DESCRIPTION
Adds grunt-s3 dependency. Allows you to deploy to aws s3. I've setup
Travis-CI as well and deployment to our prod s3 bucket will happen from
there when code hits master.