### PR TITLE
Fix Bug 1146306, restore direct referral functionality

### DIFF
--- a/src/app/lorax/config/routes.js
+++ b/src/app/lorax/config/routes.js
@@ -26,18 +26,7 @@ define(function () {
                 page: 'experience'
             })
 
-            .when('/tag/:tag', {
-                controller: 'CoreCtrl',
-                mode: 'tag',
-                page: 'experience'
-            })
-
             /* -------------------- Issue Modal -------------------- */
-
-            .when('/:topic', {
-                controller: 'CoreCtrl',
-                page: 'modal-issue'
-            })
 
             .when('/:topic/:issue', {
                 controller: 'CoreCtrl',

--- a/src/app/lorax/directives/modal-about.js
+++ b/src/app/lorax/directives/modal-about.js
@@ -26,17 +26,25 @@ define(function () {
     var ModalAboutController = function (
         $scope,
         dataService,
+        experienceService,
         windowService
     ) {
         this._$scope = $scope;
         this._dataService = dataService;
+        this._experienceService = experienceService;
         this._windowService = windowService;
 
         $scope.modalLegend = {};
         $scope.modalAbout = {
-            open: true,
+            open: false,
             closeModal: this.closeModal.bind(this)
         };
+
+        // only set the about modal to open if the current view
+        // is the ecosystem view.
+        if (this._experienceService._view === 'ecosystem') {
+            $scope.modalAbout.open = true;
+        }
 
         // listen for $broadcast of 'openAboutModal'
         $scope.$on('openAboutModal', this.openModal.bind(this));
@@ -54,6 +62,7 @@ define(function () {
     ModalAboutController.$inject = [
         '$scope',
         'dataService',
+        'experienceService',
         'windowService'
     ];
 

--- a/src/app/lorax/directives/modal-issue.js
+++ b/src/app/lorax/directives/modal-issue.js
@@ -25,6 +25,7 @@ define(['angular', 'jquery'], function (angular, $) {
         $compile,
         $location,
         $timeout,
+        routesService,
         windowService,
         dataService
     ) {
@@ -33,6 +34,7 @@ define(['angular', 'jquery'], function (angular, $) {
         this._$compile = $compile;
         this._$location = $location;
         this._$timeout = $timeout;
+        this._routesService = routesService;
         this._windowService = windowService;
         this._dataService = dataService;
 
@@ -43,6 +45,14 @@ define(['angular', 'jquery'], function (angular, $) {
 
         // listen for $broadcast of 'openIssueModal'
         $scope.$on('openIssueModal', this.openModal.bind(this));
+
+        // If an issue is accessed directly, with a URL such as:
+        // ...trust/governmentSurveillance, the routeService's page
+        // property will be set to 'modal-issue'.
+        if (this._routesService.page === 'modal-issue') {
+            // open the issue modal
+            this.openModal();
+        }
     };
 
     /**
@@ -54,6 +64,7 @@ define(['angular', 'jquery'], function (angular, $) {
         '$compile',
         '$location',
         '$timeout',
+        'routesService',
         'windowService',
         'dataService'
     ];
@@ -63,6 +74,10 @@ define(['angular', 'jquery'], function (angular, $) {
      * src/app/lorax/services/experience.js and recieves the issue to show.
      */
     ModalIssueController.prototype.openModal = function (e, issue) {
+
+        // on direct access of an issue, the issue is not passed to the
+        // function so, test for this and get it from the routeService.
+        var issue = issue ? issue : this._routesService.params.issue;
 
         this._dataService.getMain().then(function (model) {
 

--- a/src/app/lorax/services/experience.js
+++ b/src/app/lorax/services/experience.js
@@ -88,9 +88,6 @@ define(['jquery', 'experience/experience'], function ($, Experience) {
                 case 'checklist':
                     this._experience.showIssues();
                     break;
-                case 'detail':
-                    this._experience.showDetail();
-                    break;
                 default:
                     this._experience.hold();
             }


### PR DESCRIPTION
@ckprice r? This also fixes the problem with the about modal always opening on first load. This will now only open by default on the ecosystem view.